### PR TITLE
Leaderboard + endscreen integration, stats/persistence hardening, and Supabase seed tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,31 @@ Use this mode when developing auth, cloud sync, and archive persistence.
 3. Apply `supabase/schema.sql`
 4. Apply migrations in `supabase/migrations/` order
 
+### Leaderboard Test Data (Supabase)
+
+For leaderboard UI testing (top 5, personal placement, modal pagination), use the seed scripts in `supabase/seed/`.
+
+Quick flow:
+
+```sh
+# 1) Apply pending migrations (includes leaderboard RPCs)
+npx supabase db push --yes
+
+# 2) Create synthetic auth users for realistic leaderboard volume
+npx supabase db query --linked -f supabase/seed/leaderboard_auth_users_seed.sql
+
+# 3) Seed mixed outcomes for a rolling index window (daily + weekly)
+npx supabase db query --linked -f supabase/seed/leaderboard_dev_seed.sql
+```
+
+Cleanup:
+
+```sh
+npx supabase db query --linked -f supabase/seed/leaderboard_seed_cleanup.sql
+```
+
+See `supabase/seed/README.md` for details.
+
 ### Dataset-generation mode
 
 Use this mode when refreshing `get_games/*.json` source data.

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -1,0 +1,239 @@
+# kino.wtf Project Spec
+
+## Purpose
+
+This document is a high-level specification for development in this repository.
+
+It is optimized for:
+- project comprehension
+- architecture-aware implementation
+- safe feature additions without regressing game behavior, auth flows, or data integrity
+
+## Product Scope
+
+kino.wtf is a movie-themed guessing game with three modes:
+- actors (daily cadence)
+- movies (daily cadence)
+- directors (weekly cadence)
+
+The app supports:
+- anonymous/local gameplay
+- optional account-backed persistence through Supabase
+- game history and archive browsing
+- shareable results and profile settings
+
+## Tech Stack
+
+- TanStack Start + TanStack Router (file-based routes)
+- React 19 + TypeScript
+- Vite
+- Tailwind CSS + DaisyUI
+- Supabase (Auth + Postgres)
+- Vitest + ESLint + Prettier
+
+## High-Level Architecture
+
+### Route Layer
+
+Location: src/routes
+
+Responsibilities:
+- route definitions and route-local page composition
+- search param validation (for game index selection)
+- loading route-scoped datasets from get_games
+
+Rules:
+- keep route files thin
+- push game mechanics into feature hooks/components
+
+### Feature Layer
+
+Location: src/features
+
+Current feature modules:
+- gameplay
+- game-history
+
+Responsibilities:
+- domain-specific UI and behavior
+- game state and index logic
+- feature-local reusable primitives
+
+Rules:
+- feature internals should prefer local imports within the same feature
+- cross-feature usage should be intentional and minimal
+
+### Shared Application Layer
+
+Locations:
+- src/components
+- src/hooks
+- src/helpers
+- src/lib
+
+Responsibilities:
+- app-shell UI (navbar/footer/navigation scaffolding)
+- generic hooks (auth and modal lifecycle)
+- pure utility functions
+- integrations/persistence boundaries
+
+Rules:
+- shared modules must remain domain-agnostic when possible
+- feature-specific logic should migrate to src/features
+
+## Key Data and State Boundaries
+
+### Game Data
+
+Static JSON datasets are generated in get_games and consumed by routes.
+
+Contract:
+- route decides game mode dataset
+- gameplay hooks operate on selected dataset entry
+
+### Local Draft State
+
+Primary concept: local state is a draft cache.
+
+Implementation intent:
+- local storage retains in-progress game state
+- game index mismatch invalidates stale local drafts
+- local data can be used without Supabase configuration
+
+### Remote Canonical State
+
+When Supabase is configured and user is authenticated:
+- remote state is canonical for account persistence
+- stats/state/archive writes are scoped per user and mode
+- merge and sync logic must avoid overwriting fresher remote state
+
+## Auth and Persistence Decisions
+
+### Auth Providers
+
+Implemented providers:
+- email/password
+- Discord OAuth
+
+Planned providers can exist in UI scaffolding, but should not be treated as active without full backend/provider configuration.
+
+### Security Model
+
+Database uses:
+- row-level security on public tables
+- auth.uid-based policies
+- restrictive grants for authenticated role
+
+Design expectation:
+- frontend never bypasses policy assumptions
+- server-side or SQL changes must preserve user-level isolation
+
+## Migration Strategy
+
+Current approach uses a squashed baseline migration.
+
+Source of truth:
+- supabase/migrations/202603200001_initial_auth_and_games.sql
+- supabase/schema.sql (snapshot of current schema)
+
+Rules:
+- for normal evolution: add forward-only migration files
+- if environments are intentionally reset: migration squashing is acceptable
+- keep migration README in sync with chosen strategy
+
+## URL and Indexing Semantics
+
+Game selection conventions:
+- URL query game is human-facing and 1-based
+- internal game index is 0-based
+
+Required behavior:
+- validate and sanitize query values
+- convert once at route/state boundary
+- avoid mixed indexing in feature internals
+- never derive stats/counts from game index arithmetic (`game_index + 1` is display-only)
+- treat archive row counts as canonical for played/won totals
+
+## UI/UX Stability Expectations
+
+- feature modals should avoid hydration mismatch and remount flicker
+- game history interactions should preserve selected page/index intent
+- status display should be deterministic and consistent across local/remote sources
+
+## Development Modes
+
+### Frontend-only mode
+
+Use when Supabase variables are absent or placeholders.
+
+Expected behavior:
+- app runs
+- gameplay persists locally
+- auth/remote sync gracefully degrade
+
+### Supabase-enabled mode
+
+Use for auth, profile, and persistence work.
+
+Required setup:
+- environment variables from .env.example
+- schema and migration application in Supabase
+
+### Dataset-generation mode
+
+Use get_games tooling when refreshing game content.
+
+Requirements:
+- Python dependencies in get_games
+- TMDB_API_TOKEN
+
+## Testing and Validation Gate
+
+Before merging architecture-affecting changes:
+- run lint
+- run tests
+- run build (includes prerender)
+- verify primary routes render correctly
+- verify auth and persistence paths when enabled
+
+## Coding Guidelines
+
+When proposing or applying changes:
+- prefer minimal deltas with clear ownership by layer
+- avoid introducing feature logic into shared modules unless broadly reusable
+- keep import paths aligned with feature boundaries
+- preserve existing public contracts unless migration is explicit
+- update README or this spec when architecture decisions change
+
+## Common Safe Extension Patterns
+
+- Add new game-specific UI under src/features/gameplay/components
+- Add new game mechanics under src/features/gameplay/hooks
+- Add history-related enhancements under src/features/game-history
+- Add integration or persistence helpers under src/lib
+- Keep routes as composition/validation entry points
+
+## Anti-Patterns to Avoid
+
+- coupling route files directly to low-level persistence operations
+- duplicating mode conversion and storage key logic across files
+- mixing local-draft and remote-canonical responsibilities without explicit merge rules
+- adding schema changes without migration + schema snapshot updates
+
+## Decision Log Snapshot
+
+Current architectural decisions:
+1. Feature-first organization for game domains
+2. Shared layer reserved for cross-feature primitives
+3. Supabase optional at runtime; app remains usable without cloud configuration
+4. Public schema secured by RLS and auth-scoped policies
+5. Baseline migration currently squashed for release-era simplicity
+
+## Maintenance
+
+Update this file when any of the following change:
+- directory strategy and module ownership
+- auth providers or persistence model
+- migration policy
+- indexing conventions
+- required release validation gates

--- a/docs/PROJECT_SPEC.md
+++ b/docs/PROJECT_SPEC.md
@@ -5,6 +5,7 @@
 This document is a high-level specification for development in this repository.
 
 It is optimized for:
+
 - project comprehension
 - architecture-aware implementation
 - safe feature additions without regressing game behavior, auth flows, or data integrity
@@ -12,11 +13,13 @@ It is optimized for:
 ## Product Scope
 
 kino.wtf is a movie-themed guessing game with three modes:
+
 - actors (daily cadence)
 - movies (daily cadence)
 - directors (weekly cadence)
 
 The app supports:
+
 - anonymous/local gameplay
 - optional account-backed persistence through Supabase
 - game history and archive browsing
@@ -38,11 +41,13 @@ The app supports:
 Location: src/routes
 
 Responsibilities:
+
 - route definitions and route-local page composition
 - search param validation (for game index selection)
 - loading route-scoped datasets from get_games
 
 Rules:
+
 - keep route files thin
 - push game mechanics into feature hooks/components
 
@@ -51,33 +56,39 @@ Rules:
 Location: src/features
 
 Current feature modules:
+
 - gameplay
 - game-history
 
 Responsibilities:
+
 - domain-specific UI and behavior
 - game state and index logic
 - feature-local reusable primitives
 
 Rules:
+
 - feature internals should prefer local imports within the same feature
 - cross-feature usage should be intentional and minimal
 
 ### Shared Application Layer
 
 Locations:
+
 - src/components
 - src/hooks
 - src/helpers
 - src/lib
 
 Responsibilities:
+
 - app-shell UI (navbar/footer/navigation scaffolding)
 - generic hooks (auth and modal lifecycle)
 - pure utility functions
 - integrations/persistence boundaries
 
 Rules:
+
 - shared modules must remain domain-agnostic when possible
 - feature-specific logic should migrate to src/features
 
@@ -88,6 +99,7 @@ Rules:
 Static JSON datasets are generated in get_games and consumed by routes.
 
 Contract:
+
 - route decides game mode dataset
 - gameplay hooks operate on selected dataset entry
 
@@ -96,6 +108,7 @@ Contract:
 Primary concept: local state is a draft cache.
 
 Implementation intent:
+
 - local storage retains in-progress game state
 - game index mismatch invalidates stale local drafts
 - local data can be used without Supabase configuration
@@ -103,6 +116,7 @@ Implementation intent:
 ### Remote Canonical State
 
 When Supabase is configured and user is authenticated:
+
 - remote state is canonical for account persistence
 - stats/state/archive writes are scoped per user and mode
 - merge and sync logic must avoid overwriting fresher remote state
@@ -112,6 +126,7 @@ When Supabase is configured and user is authenticated:
 ### Auth Providers
 
 Implemented providers:
+
 - email/password
 - Discord OAuth
 
@@ -120,11 +135,13 @@ Planned providers can exist in UI scaffolding, but should not be treated as acti
 ### Security Model
 
 Database uses:
+
 - row-level security on public tables
 - auth.uid-based policies
 - restrictive grants for authenticated role
 
 Design expectation:
+
 - frontend never bypasses policy assumptions
 - server-side or SQL changes must preserve user-level isolation
 
@@ -133,10 +150,12 @@ Design expectation:
 Current approach uses a squashed baseline migration.
 
 Source of truth:
+
 - supabase/migrations/202603200001_initial_auth_and_games.sql
 - supabase/schema.sql (snapshot of current schema)
 
 Rules:
+
 - for normal evolution: add forward-only migration files
 - if environments are intentionally reset: migration squashing is acceptable
 - keep migration README in sync with chosen strategy
@@ -144,10 +163,12 @@ Rules:
 ## URL and Indexing Semantics
 
 Game selection conventions:
+
 - URL query game is human-facing and 1-based
 - internal game index is 0-based
 
 Required behavior:
+
 - validate and sanitize query values
 - convert once at route/state boundary
 - avoid mixed indexing in feature internals
@@ -167,6 +188,7 @@ Required behavior:
 Use when Supabase variables are absent or placeholders.
 
 Expected behavior:
+
 - app runs
 - gameplay persists locally
 - auth/remote sync gracefully degrade
@@ -176,6 +198,7 @@ Expected behavior:
 Use for auth, profile, and persistence work.
 
 Required setup:
+
 - environment variables from .env.example
 - schema and migration application in Supabase
 
@@ -184,12 +207,14 @@ Required setup:
 Use get_games tooling when refreshing game content.
 
 Requirements:
+
 - Python dependencies in get_games
 - TMDB_API_TOKEN
 
 ## Testing and Validation Gate
 
 Before merging architecture-affecting changes:
+
 - run lint
 - run tests
 - run build (includes prerender)
@@ -199,6 +224,7 @@ Before merging architecture-affecting changes:
 ## Coding Guidelines
 
 When proposing or applying changes:
+
 - prefer minimal deltas with clear ownership by layer
 - avoid introducing feature logic into shared modules unless broadly reusable
 - keep import paths aligned with feature boundaries
@@ -223,6 +249,7 @@ When proposing or applying changes:
 ## Decision Log Snapshot
 
 Current architectural decisions:
+
 1. Feature-first organization for game domains
 2. Shared layer reserved for cross-feature primitives
 3. Supabase optional at runtime; app remains usable without cloud configuration
@@ -232,6 +259,7 @@ Current architectural decisions:
 ## Maintenance
 
 Update this file when any of the following change:
+
 - directory strategy and module ownership
 - auth providers or persistence model
 - migration policy

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { Link } from '@tanstack/react-router';
 import { FaCoffee, FaGithub } from 'react-icons/fa';
 
 export default function Footer() {
@@ -50,6 +51,18 @@ export default function Footer() {
           >
             Issues?
           </a>
+        </div>
+        &bull;
+        <div>
+          <Link to="/privacy" className="link link-primary">
+            Privacy
+          </Link>
+        </div>
+        &bull;
+        <div>
+          <Link to="/terms" className="link link-primary">
+            Terms
+          </Link>
         </div>
       </div>
     </footer>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -107,7 +107,7 @@ export default function Navbar() {
             <div className="tooltip tooltip-bottom" data-tip="Sign in">
               <Link to="/auth" tabIndex={0} className="btn btn-ghost btn-sm btn-circle">
                 <div className="avatar avatar-placeholder">
-                  <div className="bg-neutral text-primary-content w-8 rounded-full">
+                  <div className="w-8 rounded-full">
                     <span className="text-xs">
                       <FaUser />
                     </span>

--- a/src/features/gameplay/components/GameLeaderboard.tsx
+++ b/src/features/gameplay/components/GameLeaderboard.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { GameMode, LeaderboardEntry } from '../../../lib/gamePersistence';
+import {
+  loadGameLeaderboardPage,
+  loadGameLeaderboardPlacement,
+} from '../../../lib/gamePersistence';
+
+interface GameLeaderboardProps {
+  gameMode: GameMode;
+  gameIndex: number;
+  userId?: string | null;
+  enabled: boolean;
+  pageSize?: number;
+  showPagination?: boolean;
+  showCurrentUserPlacement?: boolean;
+  title?: string;
+  showTitle?: boolean;
+}
+
+export default function GameLeaderboard({
+  gameMode,
+  gameIndex,
+  userId,
+  enabled,
+  pageSize = 5,
+  showPagination = false,
+  showCurrentUserPlacement = false,
+  title = 'Leaderboard',
+  showTitle = true,
+}: GameLeaderboardProps) {
+  const [page, setPage] = useState(1);
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [totalCount, setTotalCount] = useState(0);
+  const [myPlacement, setMyPlacement] = useState<LeaderboardEntry | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const activePage = showPagination ? page : 1;
+  const pageCount = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  useEffect(() => {
+    setPage(1);
+  }, [gameMode, gameIndex]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    if (!enabled) {
+      setEntries([]);
+      setTotalCount(0);
+      setMyPlacement(null);
+      setError(null);
+      return () => {
+        mounted = false;
+      };
+    }
+
+    setLoading(true);
+    setError(null);
+
+    const loadData = async () => {
+      try {
+        const [pageData, placementData] = await Promise.all([
+          loadGameLeaderboardPage({
+            gameMode,
+            gameIndex,
+            page: activePage,
+            pageSize,
+          }),
+          showCurrentUserPlacement && userId
+            ? loadGameLeaderboardPlacement({
+                gameMode,
+                gameIndex,
+                userId,
+              })
+            : Promise.resolve(null),
+        ]);
+
+        if (!mounted) return;
+
+        setEntries(pageData.entries);
+        setTotalCount(pageData.totalCount);
+        setMyPlacement(placementData);
+      } catch {
+        if (!mounted) return;
+        setEntries([]);
+        setTotalCount(0);
+        setMyPlacement(null);
+        setError('Could not load leaderboard right now.');
+      } finally {
+        if (mounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadData();
+
+    return () => {
+      mounted = false;
+    };
+  }, [activePage, enabled, gameIndex, gameMode, pageSize, showCurrentUserPlacement, userId]);
+
+  const visibleUserIds = useMemo(() => new Set(entries.map((entry) => entry.userId)), [entries]);
+
+  const shouldAppendMyPlacement = Boolean(
+    showCurrentUserPlacement &&
+      myPlacement &&
+      myPlacement.rank > 5 &&
+      (userId ? !visibleUserIds.has(userId) : true),
+  );
+
+  if (!enabled) {
+    return (
+      <div className="card bg-base-200 shadow">
+        <div className="card-body p-3 text-center">
+          <p className="text-sm text-base-content/70">Leaderboard is unavailable in local-only mode.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card bg-base-200 shadow">
+      <div className="card-body p-3 gap-3">
+        {showTitle ? <h3 className="font-display text-lg">{title}</h3> : null}
+
+        {loading ? <span className="loading loading-spinner loading-sm self-center" /> : null}
+
+        {error ? <p className="text-sm text-error text-center">{error}</p> : null}
+
+        {!loading && !error && entries.length === 0 ? (
+          <p className="text-sm text-base-content/70 text-center">No winners have finished yet.</p>
+        ) : null}
+
+        {entries.length > 0 ? (
+          <ul className="flex flex-col gap-2">
+            {entries.map((entry) => {
+              const isMe = Boolean(userId && entry.userId === userId);
+
+              return (
+                <li
+                  key={`${entry.rank}-${entry.userId}`}
+                  className={[
+                    'flex items-center justify-between rounded-box border px-3 py-2 text-sm',
+                    isMe ? 'border-primary bg-primary/10' : 'border-base-300 bg-base-100',
+                  ].join(' ')}
+                >
+                  <span className="font-mono w-12">#{entry.rank}</span>
+                  <span className="flex-1 truncate px-2">{entry.username}</span>
+                  <span className="badge badge-success">{entry.guessCount}/6</span>
+                </li>
+              );
+            })}
+          </ul>
+        ) : null}
+
+        {shouldAppendMyPlacement && myPlacement ? (
+          <>
+            <div className="divider my-0">...</div>
+            <div className="flex items-center justify-between rounded-box border border-primary bg-primary/10 px-3 py-2 text-sm">
+              <span className="font-mono w-12">#{myPlacement.rank}</span>
+              <span className="flex-1 truncate px-2">{myPlacement.username}</span>
+              <span className="badge badge-success">{myPlacement.guessCount}/6</span>
+            </div>
+          </>
+        ) : null}
+
+        {showPagination && totalCount > pageSize ? (
+          <div className="flex items-center justify-between gap-2">
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => setPage((prev) => Math.max(1, prev - 1))}
+              disabled={activePage <= 1}
+            >
+              Prev
+            </button>
+            <span className="text-xs text-base-content/70">
+              Page {activePage} / {pageCount}
+            </span>
+            <button
+              type="button"
+              className="btn btn-sm"
+              onClick={() => setPage((prev) => Math.min(pageCount, prev + 1))}
+              disabled={activePage >= pageCount}
+            >
+              Next
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/features/gameplay/components/GameLeaderboard.tsx
+++ b/src/features/gameplay/components/GameLeaderboard.tsx
@@ -105,16 +105,18 @@ export default function GameLeaderboard({
 
   const shouldAppendMyPlacement = Boolean(
     showCurrentUserPlacement &&
-      myPlacement &&
-      myPlacement.rank > 5 &&
-      (userId ? !visibleUserIds.has(userId) : true),
+    myPlacement &&
+    myPlacement.rank > 5 &&
+    (userId ? !visibleUserIds.has(userId) : true),
   );
 
   if (!enabled) {
     return (
       <div className="card bg-base-200 shadow">
         <div className="card-body p-3 text-center">
-          <p className="text-sm text-base-content/70">Leaderboard is unavailable in local-only mode.</p>
+          <p className="text-sm text-base-content/70">
+            Leaderboard is unavailable in local-only mode.
+          </p>
         </div>
       </div>
     );

--- a/src/features/gameplay/components/GameNavigation.tsx
+++ b/src/features/gameplay/components/GameNavigation.tsx
@@ -1,22 +1,32 @@
-import { FaChartBar, FaInfoCircle } from 'react-icons/fa';
+import { FaChartBar, FaInfoCircle, FaTrophy } from 'react-icons/fa';
 import useModal from '../../../hooks/useModal';
 import { type Route } from '../../../routes';
 import type { GameStats } from './DisplayStats';
 import DisplayStats from './DisplayStats';
 import GameHistoryModal from '../../game-history/components/GameHistoryModal';
+import useAuth from '../../../hooks/useAuth';
+import { toGameMode } from '../../../lib/gameMode';
+import GameLeaderboard from './GameLeaderboard';
 
 export default function GameNavigation({
   stats,
   AboutContent,
   route,
   gameIndex,
+  onOpenLeaderboard,
+  showInlineLeaderboardModal = true,
 }: {
   stats: GameStats;
   AboutContent: React.FC;
   route: Route;
   gameIndex: number;
+  onOpenLeaderboard?: () => void;
+  showInlineLeaderboardModal?: boolean;
 }) {
+  const { user, isConfigured } = useAuth();
+  const gameMode = toGameMode(route.title);
   const { Modal: StatsModal, open: openStatsModal } = useModal();
+  const { Modal: LeaderboardModal, open: openLeaderboardModal } = useModal();
   const { Modal: AboutModal, open: openAboutModal } = useModal();
 
   return (
@@ -38,8 +48,36 @@ export default function GameNavigation({
             <DisplayStats stats={stats} />
           </div>
         </StatsModal>
+        {gameMode ? (
+          <>
+            <button
+              className="btn btn-ghost btn-square tooltip tooltip-right sm:tooltip-top"
+              data-tip="Leaderboard"
+              onClick={() => (onOpenLeaderboard ? onOpenLeaderboard() : openLeaderboardModal())}
+            >
+              <FaTrophy />
+            </button>
+            {showInlineLeaderboardModal ? (
+              <LeaderboardModal>
+                <h2 className="font-bold text-xl mb-4 text-primary">
+                  <FaTrophy className="inline" />
+                  &nbsp;Leaderboard
+                </h2>
+                <GameLeaderboard
+                  enabled={isConfigured}
+                  gameMode={gameMode}
+                  gameIndex={gameIndex}
+                  userId={user?.id ?? null}
+                  pageSize={25}
+                  showPagination
+                  showTitle={false}
+                />
+              </LeaderboardModal>
+            ) : null}
+          </>
+        ) : null}
       </div>
-      <h2 className="navbar-center font-display text-xl">
+      <h2 className="navbar-center font-display text-lg">
         {route.emoji}&nbsp;{route.title}&nbsp;#{gameIndex + 1}
       </h2>
       <div className="navbar-end">

--- a/src/features/gameplay/hooks/useGame.tsx
+++ b/src/features/gameplay/hooks/useGame.tsx
@@ -105,7 +105,8 @@ export default function useGame(
 ) {
   const { user, isConfigured } = useAuth();
   const gameMode = toGameMode(route.title);
-  const currentStatsBootstrapKey = isConfigured && user && gameMode ? `${user.id}:${gameMode}` : null;
+  const currentStatsBootstrapKey =
+    isConfigured && user && gameMode ? `${user.id}:${gameMode}` : null;
   const currentCompletionBootstrapKey =
     isConfigured && user && gameMode ? `${user.id}:${gameMode}:${gameIndex}` : null;
 
@@ -182,7 +183,9 @@ export default function useGame(
   const [stats, setStats] = useState<GameStats>(savedStats);
   const [isSyncPending, setIsSyncPending] = useState<boolean>(savedStateSnapshot.syncPending);
   const [statsBootstrapReadyKey, setStatsBootstrapReadyKey] = useState<string | null>(null);
-  const [completionBootstrapReadyKey, setCompletionBootstrapReadyKey] = useState<string | null>(null);
+  const [completionBootstrapReadyKey, setCompletionBootstrapReadyKey] = useState<string | null>(
+    null,
+  );
   const completionAlreadyAccountedRef = useRef<boolean>(savedStateSnapshot.gameOver > 0);
   const initialRemoteStatsRef = useRef<GameStats | null>(null);
   const remoteStateRef =
@@ -724,7 +727,9 @@ export default function useGame(
       </form>
 
       {!isCompletionHydrated ? (
-        <p className="text-xs text-base-content/70 text-center">Checking cloud completion state...</p>
+        <p className="text-xs text-base-content/70 text-center">
+          Checking cloud completion state...
+        </p>
       ) : null}
 
       <h4>

--- a/src/features/gameplay/hooks/useGame.tsx
+++ b/src/features/gameplay/hooks/useGame.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import ExpandableModal from '../../../components/ExpandableModal';
 import Countdown from '../components/Countdown';
@@ -7,16 +7,19 @@ import DisplayStats from '../components/DisplayStats';
 import ShareButton from '../components/ShareButton';
 import GuessBox from '../components/GuessBox';
 import LoadingImage from '../components/LoadingImage';
+import GameLeaderboard from '../components/GameLeaderboard';
 
 import type { GameStats } from '../components/DisplayStats';
 import type { Route } from '../../../routes';
 import useAuth from '../../../hooks/useAuth';
 import {
+  loadPlayedGameForIndex,
   loadGameState,
   loadGameStats,
   recordPlayedGame,
   saveGameState,
   saveGameStats,
+  validateGameStatsIntegrity,
 } from '../../../lib/gamePersistence';
 import { toGameMode } from '../../../lib/gameMode';
 import {
@@ -45,9 +48,66 @@ interface Game {
   }[];
 }
 
-export default function useGame(route: Route, games: Game[], gameIndex: number) {
+function areStatsEqual(a: GameStats, b: GameStats) {
+  return (
+    a.gamesPlayed === b.gamesPlayed &&
+    a.gamesWon === b.gamesWon &&
+    a.streak === b.streak &&
+    a.maxStreak === b.maxStreak
+  );
+}
+
+function stateSignature(input: {
+  gameIndex: number;
+  guess: string;
+  guesses: string[];
+  gameOver: 0 | 1 | 2;
+}) {
+  return JSON.stringify([
+    input.gameIndex,
+    input.gameOver,
+    input.guess,
+    input.guesses.length,
+    input.guesses,
+  ]);
+}
+
+function normalizeWinningGuessesForDisplay(params: {
+  guesses: string[];
+  didWin: boolean;
+  answerTitle: string;
+}) {
+  const { guesses, didWin, answerTitle } = params;
+  const nextGuesses = Array.isArray(guesses) ? [...guesses] : [];
+
+  if (!didWin) return nextGuesses;
+
+  const hasCorrectGuess = nextGuesses.some(
+    (entry) => entry?.toLowerCase() === answerTitle.toLowerCase(),
+  );
+  if (hasCorrectGuess) return nextGuesses;
+
+  const patchIndex = Math.max(0, Math.min(5, nextGuesses.length - 1));
+  if (nextGuesses.length === 0) {
+    nextGuesses.push(answerTitle);
+    return nextGuesses;
+  }
+
+  nextGuesses[patchIndex] = answerTitle;
+  return nextGuesses;
+}
+
+export default function useGame(
+  route: Route,
+  games: Game[],
+  gameIndex: number,
+  onOpenLeaderboard?: () => void,
+) {
   const { user, isConfigured } = useAuth();
   const gameMode = toGameMode(route.title);
+  const currentStatsBootstrapKey = isConfigured && user && gameMode ? `${user.id}:${gameMode}` : null;
+  const currentCompletionBootstrapKey =
+    isConfigured && user && gameMode ? `${user.id}:${gameMode}:${gameIndex}` : null;
 
   /**
    * Local cache snapshot for the selected game index.
@@ -120,9 +180,17 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
   const [guesses, setGuesses] = useState<string[]>(savedStateSnapshot.guesses);
   const [gameOver, setGameOver] = useState<0 | 1 | 2>(savedStateSnapshot.gameOver);
   const [stats, setStats] = useState<GameStats>(savedStats);
-  const remoteReadyRef = useRef<boolean>(!isConfigured || !user || !gameMode);
+  const [isSyncPending, setIsSyncPending] = useState<boolean>(savedStateSnapshot.syncPending);
+  const [statsBootstrapReadyKey, setStatsBootstrapReadyKey] = useState<string | null>(null);
+  const [completionBootstrapReadyKey, setCompletionBootstrapReadyKey] = useState<string | null>(null);
+  const completionAlreadyAccountedRef = useRef<boolean>(savedStateSnapshot.gameOver > 0);
+  const initialRemoteStatsRef = useRef<GameStats | null>(null);
   const remoteStateRef =
     useRef<ReturnType<typeof loadGameState> extends Promise<infer T> ? T : null>(null);
+  const lastPersistedStateSignatureRef = useRef<string | null>(null);
+  const inFlightStateSignatureRef = useRef<string | null>(null);
+  const saveDebounceTimerRef = useRef<number | null>(null);
+  const statsIntegrityCheckedKeyRef = useRef<string | null>(null);
   const localUpdatedAtRef = useRef<number>(savedStateSnapshot.updatedAt);
   const localSyncPendingRef = useRef<boolean>(savedStateSnapshot.syncPending);
   const guessOptions = useMemo(
@@ -135,6 +203,8 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
   );
 
   const game: Game = games[gameIndex % games.length];
+  const isCompletionHydrated =
+    !currentCompletionBootstrapKey || completionBootstrapReadyKey === currentCompletionBootstrapKey;
 
   /**
    * Bootstrap local state from remote storage and apply deterministic conflict resolution.
@@ -150,16 +220,13 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
     let mounted = true;
 
     if (!isConfigured || !user || !gameMode) {
-      remoteReadyRef.current = true;
       return () => {
         mounted = false;
       };
     }
 
-    remoteReadyRef.current = false;
-
-    Promise.all([loadGameState(user.id, gameMode), loadGameStats(user.id, gameMode)])
-      .then(([remoteState, remoteStats]) => {
+    loadGameState(user.id, gameMode)
+      .then((remoteState) => {
         if (!mounted) return;
 
         remoteStateRef.current = remoteState;
@@ -179,27 +246,69 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
             setGuess(remoteState.guess ?? '');
             setGuesses(remoteGuesses);
             setGameOver(remoteState.game_over ?? 0);
+            if ((remoteState.game_over ?? 0) > 0) {
+              completionAlreadyAccountedRef.current = true;
+            }
 
             localSyncPendingRef.current = false;
+            setIsSyncPending(false);
             localUpdatedAtRef.current = Date.now();
           }
         }
-
-        if (remoteStats) {
-          setStats({
-            gamesPlayed: remoteStats.gamesPlayed,
-            gamesWon: remoteStats.gamesWon,
-            streak: remoteStats.streak,
-            maxStreak: remoteStats.maxStreak,
-          });
-        }
-
-        remoteReadyRef.current = true;
       })
       .catch((error) => {
         console.error('Failed to load remote game state', error);
+      });
+
+    loadPlayedGameForIndex({ userId: user.id, gameMode, gameIndex })
+      .then((playedRecord) => {
+        if (!mounted || !playedRecord) return;
+
+        // Archive completion is canonical for resolved games.
+        const normalizedGuesses = normalizeWinningGuessesForDisplay({
+          guesses: Array.isArray(playedRecord.guesses) ? playedRecord.guesses : [],
+          didWin: playedRecord.did_win,
+          answerTitle: game.answer.title,
+        });
+
+        setGuess('');
+        setGuesses(normalizedGuesses);
+        setGameOver(playedRecord.did_win ? 2 : 1);
+        completionAlreadyAccountedRef.current = true;
+        localSyncPendingRef.current = false;
+        setIsSyncPending(false);
+        localUpdatedAtRef.current = Date.now();
+      })
+      .catch((error) => {
+        console.error('Failed to load played game archive state', error);
+      })
+      .finally(() => {
         if (!mounted) return;
-        remoteReadyRef.current = true;
+        setCompletionBootstrapReadyKey(`${user.id}:${gameMode}:${gameIndex}`);
+      });
+
+    loadGameStats(user.id, gameMode)
+      .then((remoteStats) => {
+        if (!mounted || !remoteStats) return;
+        initialRemoteStatsRef.current = {
+          gamesPlayed: remoteStats.gamesPlayed,
+          gamesWon: remoteStats.gamesWon,
+          streak: remoteStats.streak,
+          maxStreak: remoteStats.maxStreak,
+        };
+        setStats({
+          gamesPlayed: remoteStats.gamesPlayed,
+          gamesWon: remoteStats.gamesWon,
+          streak: remoteStats.streak,
+          maxStreak: remoteStats.maxStreak,
+        });
+      })
+      .catch((error) => {
+        console.error('Failed to load remote stats', error);
+      })
+      .finally(() => {
+        if (!mounted) return;
+        setStatsBootstrapReadyKey(`${user.id}:${gameMode}`);
       });
 
     return () => {
@@ -212,7 +321,27 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
     savedStateSnapshot.gameOver,
     savedStateSnapshot.guesses,
     user,
+    game.answer.title,
   ]);
+
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+    if (!isConfigured || !user || !gameMode) return;
+
+    const key = `${user.id}:all-modes`;
+    if (statsIntegrityCheckedKeyRef.current === key) return;
+    statsIntegrityCheckedKeyRef.current = key;
+
+    validateGameStatsIntegrity(user.id)
+      .then((report) => {
+        const mismatches = report.entries.filter((entry) => !entry.matches);
+        if (mismatches.length === 0) return;
+        console.warn('Game stats integrity mismatch detected', mismatches);
+      })
+      .catch((error) => {
+        console.warn('Failed to run stats integrity validation', error);
+      });
+  }, [gameMode, isConfigured, user]);
 
   // Save stats to localStorage whenever they change
   useEffect(() => {
@@ -221,12 +350,35 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
   }, [stats, route]);
 
   useEffect(() => {
-    if (!remoteReadyRef.current || !isConfigured || !user || !gameMode) return;
+    if (!isConfigured || !user || !gameMode) return;
+    if (!currentStatsBootstrapKey || statsBootstrapReadyKey !== currentStatsBootstrapKey) return;
+
+    const initialRemoteStats = initialRemoteStatsRef.current;
+    if (initialRemoteStats && areStatsEqual(initialRemoteStats, stats)) {
+      initialRemoteStatsRef.current = null;
+      return;
+    }
 
     saveGameStats(user.id, gameMode, stats).catch((error) => {
       console.error('Failed to save remote stats', error);
     });
-  }, [gameMode, isConfigured, stats, user]);
+  }, [currentStatsBootstrapKey, gameMode, isConfigured, stats, statsBootstrapReadyKey, user]);
+
+  const updateStats = useCallback((gameStatus: number) => {
+    setStats((currentStats) => {
+      const newGamesPlayed = currentStats.gamesPlayed + 1;
+      const newGamesWon = gameStatus === 2 ? currentStats.gamesWon + 1 : currentStats.gamesWon;
+      const newStreak = gameStatus === 2 ? currentStats.streak + 1 : 0;
+      const newMaxStreak = newStreak > currentStats.maxStreak ? newStreak : currentStats.maxStreak;
+
+      return {
+        gamesPlayed: newGamesPlayed,
+        gamesWon: newGamesWon,
+        streak: newStreak,
+        maxStreak: newMaxStreak,
+      };
+    });
+  }, []);
 
   // Save state to localStorage whenever it changes
   useEffect(() => {
@@ -249,7 +401,7 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
   }, [guess, guesses, gameOver, game, route, gameIndex]);
 
   useEffect(() => {
-    if (!remoteReadyRef.current || !isConfigured || !user || !gameMode) return;
+    if (!isConfigured || !user || !gameMode) return;
 
     /**
      * Guard against downgrading a remote completed record with a local in-progress snapshot.
@@ -263,6 +415,28 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
       return;
     }
 
+    const nextSignature = stateSignature({ gameIndex, guess, guesses, gameOver });
+    if (nextSignature === lastPersistedStateSignatureRef.current) {
+      return;
+    }
+    if (nextSignature === inFlightStateSignatureRef.current) {
+      return;
+    }
+
+    if (
+      knownRemote &&
+      knownRemote.game_index === gameIndex &&
+      stateSignature({
+        gameIndex,
+        guess: knownRemote.guess ?? '',
+        guesses: Array.isArray(knownRemote.guesses) ? knownRemote.guesses : [],
+        gameOver: (knownRemote.game_over ?? 0) as 0 | 1 | 2,
+      }) === nextSignature
+    ) {
+      lastPersistedStateSignatureRef.current = nextSignature;
+      return;
+    }
+
     const nextState = {
       user_id: user.id,
       game_mode: gameMode,
@@ -272,43 +446,61 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
       game_over: gameOver,
     } as const;
 
-    saveGameState(nextState)
-      .then(() => {
-        remoteStateRef.current = nextState;
-        localSyncPendingRef.current = false;
+    if (typeof window !== 'undefined' && saveDebounceTimerRef.current !== null) {
+      window.clearTimeout(saveDebounceTimerRef.current);
+    }
 
-        if (typeof window === 'undefined') return;
+    if (typeof window === 'undefined') return;
 
-        const parsed = readStoredGameState(route.title);
-        if (!parsed) return;
+    saveDebounceTimerRef.current = window.setTimeout(() => {
+      inFlightStateSignatureRef.current = nextSignature;
 
-        const sameState =
-          parsed.gameIndex === gameIndex &&
-          parsed.gameOver === gameOver &&
-          parsed.guess === guess &&
-          parsed.guesses.length === guesses.length &&
-          parsed.guesses.every((entry: string, idx: number) => entry === guesses[idx]);
+      saveGameState(nextState)
+        .then(() => {
+          remoteStateRef.current = nextState;
+          lastPersistedStateSignatureRef.current = nextSignature;
+          inFlightStateSignatureRef.current = null;
+          localSyncPendingRef.current = false;
+          setIsSyncPending(false);
 
-        if (!sameState) return;
+          const parsed = readStoredGameState(route.title);
+          if (!parsed) return;
 
-        const synced: StoredGameState = {
-          guess,
-          guesses,
-          gameIndex: gameIndex,
-          gameOver,
-          updatedAt: localUpdatedAtRef.current,
-          syncPending: false,
-        };
+          const sameState =
+            parsed.gameIndex === gameIndex &&
+            parsed.gameOver === gameOver &&
+            parsed.guess === guess &&
+            parsed.guesses.length === guesses.length &&
+            parsed.guesses.every((entry: string, idx: number) => entry === guesses[idx]);
 
-        writeStoredGameState(route.title, synced);
-      })
-      .catch((error) => {
-        console.error('Failed to save remote game state', error);
-      });
+          if (!sameState) return;
+
+          const synced: StoredGameState = {
+            guess,
+            guesses,
+            gameIndex: gameIndex,
+            gameOver,
+            updatedAt: localUpdatedAtRef.current,
+            syncPending: false,
+          };
+
+          writeStoredGameState(route.title, synced);
+        })
+        .catch((error) => {
+          inFlightStateSignatureRef.current = null;
+          console.error('Failed to save remote game state', error);
+        });
+    }, 250);
+
+    return () => {
+      if (saveDebounceTimerRef.current !== null) {
+        window.clearTimeout(saveDebounceTimerRef.current);
+      }
+    };
   }, [gameMode, gameIndex, gameOver, guess, guesses, isConfigured, route.title, user]);
 
   useEffect(() => {
-    if (!remoteReadyRef.current || !isConfigured || !user || !gameMode) return;
+    if (!isConfigured || !user || !gameMode) return;
     if (gameOver === 0) return;
 
     recordPlayedGame({
@@ -323,41 +515,47 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
     });
   }, [game.answer.title, gameIndex, gameMode, gameOver, guesses, isConfigured, user]);
 
-  // Update stats when the game is over
-  function updateStats(gameStatus: number) {
-    const newGamesPlayed = stats.gamesPlayed + 1;
-    const newGamesWon = gameStatus === 2 ? stats.gamesWon + 1 : stats.gamesWon;
-    const newStreak = gameStatus === 2 ? stats.streak + 1 : 0;
-    const newMaxStreak = newStreak > stats.maxStreak ? newStreak : stats.maxStreak;
-
-    setStats({
-      gamesPlayed: newGamesPlayed,
-      gamesWon: newGamesWon,
-      streak: newStreak,
-      maxStreak: newMaxStreak,
-    });
-  }
-
   // Listen for guesses
   function onGuess(newGuess: string) {
-    setGuesses((g) => [...g, newGuess]);
+    if (gameOver > 0) return;
+    if (!isCompletionHydrated) return;
 
-    // check if game is over
-    if (newGuess.toLowerCase() === game.answer.title.toLowerCase()) {
-      setGameOver(2);
-      updateStats(2);
-    } else if (guesses.length === 5) {
-      setGameOver(1);
-      updateStats(1);
-    }
+    setGuesses((g) => {
+      const next = [...g, newGuess];
+
+      if (newGuess.toLowerCase() === game.answer.title.toLowerCase()) {
+        if (!completionAlreadyAccountedRef.current) {
+          completionAlreadyAccountedRef.current = true;
+          updateStats(2);
+        }
+        setIsSyncPending(true);
+        setGameOver(2);
+      } else if (next.length >= 6) {
+        if (!completionAlreadyAccountedRef.current) {
+          completionAlreadyAccountedRef.current = true;
+          updateStats(1);
+        }
+        setIsSyncPending(true);
+        setGameOver(1);
+      }
+
+      return next;
+    });
 
     setGuess('');
   }
 
   function handleGiveUp() {
-    setGuesses((g) => [...g, ...Array.from({ length: 6 - g.length }, () => '')]);
+    if (gameOver > 0) return;
+    if (!isCompletionHydrated) return;
+
+    setGuesses((g) => [...g, ...Array.from({ length: Math.max(0, 6 - g.length) }, () => '')]);
+    if (!completionAlreadyAccountedRef.current) {
+      completionAlreadyAccountedRef.current = true;
+      updateStats(1);
+    }
+    setIsSyncPending(true);
     setGameOver(1);
-    updateStats(1);
     setGuess('');
   }
 
@@ -368,12 +566,14 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
           <div className="card card-side bg-base-200 shadow">
             <figure className="w-1/3">
               <ExpandableModal>
-                <LoadingImage
-                  key={game.answer.image}
-                  src={game.answer.image}
-                  alt={game.answer.title}
-                  wrapperClassName="w-full"
-                />
+                <div>
+                  <LoadingImage
+                    key={game.answer.image}
+                    src={game.answer.image}
+                    alt={game.answer.title}
+                    wrapperClassName="w-full"
+                  />
+                </div>
               </ExpandableModal>
             </figure>
             <div className="card-body text-center">
@@ -406,6 +606,31 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
             answer={game.answer.title}
             route={route}
           />
+
+          {isConfigured && user && isSyncPending ? (
+            <div className="alert alert-info py-2 text-sm">
+              <span className="loading loading-spinner loading-xs" />
+              <span>Syncing from cloud...</span>
+            </div>
+          ) : null}
+
+          {gameMode ? (
+            <GameLeaderboard
+              enabled={isConfigured}
+              gameMode={gameMode}
+              gameIndex={gameIndex}
+              userId={user?.id ?? null}
+              pageSize={5}
+              showCurrentUserPlacement
+              title="Today's Top 5"
+            />
+          ) : null}
+
+          {gameMode && onOpenLeaderboard ? (
+            <button className="btn btn-outline w-full" onClick={onOpenLeaderboard} type="button">
+              View Full Leaderboard
+            </button>
+          ) : null}
 
           <h2 className="text-xl font-medium text-center">More games:</h2>
           <RouteLinks />
@@ -485,18 +710,22 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
       >
         <GuessBox
           options={guessOptions}
-          disabled={guesses.length === 6 || gameOver > 0}
+          disabled={guesses.length === 6 || gameOver > 0 || !isCompletionHydrated}
           state={guess}
           setState={setGuess}
         />
 
         <button
           className={['btn join-item', guess ? 'btn-primary' : 'btn-soft'].join('\x20')}
-          disabled={guesses.length === 6 || gameOver > 0}
+          disabled={guesses.length === 6 || gameOver > 0 || !isCompletionHydrated}
         >
           {guess ? 'Guess' : 'Skip'}
         </button>
       </form>
+
+      {!isCompletionHydrated ? (
+        <p className="text-xs text-base-content/70 text-center">Checking cloud completion state...</p>
+      ) : null}
 
       <h4>
         <b>Guesses:</b>&nbsp;({guesses.length}/6)
@@ -530,7 +759,7 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
 
       <button
         className="btn btn-error mx-auto shadow"
-        disabled={guesses.length === 6 || gameOver > 0}
+        disabled={guesses.length === 6 || gameOver > 0 || !isCompletionHydrated}
         onClick={handleGiveUp}
       >
         Give up
@@ -538,5 +767,5 @@ export default function useGame(route: Route, games: Game[], gameIndex: number) 
     </section>
   );
 
-  return { stats, gameBoard };
+  return { stats, gameBoard, isSyncPending };
 }

--- a/src/lib/gamePersistence.ts
+++ b/src/lib/gamePersistence.ts
@@ -31,6 +31,31 @@ export interface PlayedGameRecord {
   finished_at: string;
 }
 
+export interface LeaderboardEntry {
+  rank: number;
+  userId: string;
+  username: string;
+  guessCount: number;
+  finishedAt: string;
+}
+
+export interface LeaderboardPage {
+  entries: LeaderboardEntry[];
+  totalCount: number;
+}
+
+export interface StatsIntegrityEntry {
+  gameMode: GameMode;
+  expected: GameStats;
+  actual: GameStats;
+  matches: boolean;
+}
+
+export interface StatsIntegrityReport {
+  entries: StatsIntegrityEntry[];
+  allMatch: boolean;
+}
+
 function isTransientDatabaseError(error: unknown) {
   if (!error || typeof error !== 'object') return false;
 
@@ -191,6 +216,214 @@ export async function loadPlayedGames(userId: string, limit = 200) {
     throw new Error(`Archive query failed: ${detail}`);
   }
   return data ?? [];
+}
+
+export async function loadPlayedGameForIndex(input: {
+  userId: string;
+  gameMode: GameMode;
+  gameIndex: number;
+}): Promise<PlayedGameRecord | null> {
+  if (!supabase) return null;
+
+  const { data, error } = await supabase
+    .from('played_games')
+    .select('id, game_mode, game_index, answer_title, did_win, guesses, finished_at')
+    .eq('user_id', input.userId)
+    .eq('game_mode', input.gameMode)
+    .eq('game_index', input.gameIndex)
+    .maybeSingle<PlayedGameRecord>();
+
+  if (error) {
+    if (isTransientDatabaseError(error)) return null;
+    throw error;
+  }
+
+  return data ?? null;
+}
+
+function buildStatsFromPlayedRecords(records: PlayedGameRecord[]): GameStats {
+  if (!records.length) {
+    return {
+      gamesPlayed: 0,
+      gamesWon: 0,
+      streak: 0,
+      maxStreak: 0,
+    };
+  }
+
+  const ordered = [...records].sort((a, b) => {
+    if (a.game_index !== b.game_index) return a.game_index - b.game_index;
+    const left = new Date(a.finished_at).getTime();
+    const right = new Date(b.finished_at).getTime();
+    return left - right;
+  });
+
+  let gamesPlayed = 0;
+  let gamesWon = 0;
+  let streak = 0;
+  let maxStreak = 0;
+
+  for (const record of ordered) {
+    gamesPlayed += 1;
+    if (record.did_win) {
+      gamesWon += 1;
+      streak += 1;
+      if (streak > maxStreak) maxStreak = streak;
+    } else {
+      streak = 0;
+    }
+  }
+
+  return {
+    gamesPlayed,
+    gamesWon,
+    streak,
+    maxStreak,
+  };
+}
+
+export async function validateGameStatsIntegrity(userId: string): Promise<StatsIntegrityReport> {
+  const modes: GameMode[] = ['actors', 'movies', 'directors'];
+
+  const [played, statsByMode] = await Promise.all([
+    loadPlayedGames(userId, 2000),
+    Promise.all(
+      modes.map(async (mode) => {
+        const stats = await loadGameStats(userId, mode);
+        return {
+          mode,
+          stats: stats ?? {
+            gamesPlayed: 0,
+            gamesWon: 0,
+            streak: 0,
+            maxStreak: 0,
+          },
+        };
+      }),
+    ),
+  ]);
+
+  const entries: StatsIntegrityEntry[] = modes.map((mode) => {
+    const modePlayed = played.filter((entry) => entry.game_mode === mode);
+    const expected = buildStatsFromPlayedRecords(modePlayed);
+    const actual = statsByMode.find((item) => item.mode === mode)?.stats ?? {
+      gamesPlayed: 0,
+      gamesWon: 0,
+      streak: 0,
+      maxStreak: 0,
+    };
+
+    const matches =
+      expected.gamesPlayed === actual.gamesPlayed &&
+      expected.gamesWon === actual.gamesWon &&
+      expected.streak === actual.streak &&
+      expected.maxStreak === actual.maxStreak;
+
+    return {
+      gameMode: mode,
+      expected,
+      actual,
+      matches,
+    };
+  });
+
+  return {
+    entries,
+    allMatch: entries.every((entry) => entry.matches),
+  };
+}
+
+export async function loadGameLeaderboardPage(input: {
+  gameMode: GameMode;
+  gameIndex: number;
+  page: number;
+  pageSize: number;
+}): Promise<LeaderboardPage> {
+  if (!supabase) {
+    return {
+      entries: [],
+      totalCount: 0,
+    };
+  }
+
+  const safePage = Math.max(1, Math.floor(input.page));
+  const safePageSize = Math.max(1, Math.floor(input.pageSize));
+
+  const { data, error } = await supabase.rpc('get_game_leaderboard_page', {
+    p_game_mode: input.gameMode,
+    p_game_index: input.gameIndex,
+    p_page: safePage,
+    p_page_size: safePageSize,
+  });
+
+  if (error) {
+    if (isTransientDatabaseError(error)) {
+      return {
+        entries: [],
+        totalCount: 0,
+      };
+    }
+    throw error;
+  }
+
+  const rows = (data ?? []) as Array<{
+    rank: number;
+    user_id: string;
+    username: string | null;
+    guess_count: number;
+    finished_at: string;
+    total_count: number;
+  }>;
+
+  return {
+    entries: rows.map((row) => ({
+      rank: Number(row.rank ?? 0),
+      userId: row.user_id,
+      username: row.username ?? 'unknown',
+      guessCount: Number(row.guess_count ?? 0),
+      finishedAt: row.finished_at,
+    })),
+    totalCount: Number(rows[0]?.total_count ?? 0),
+  };
+}
+
+export async function loadGameLeaderboardPlacement(input: {
+  gameMode: GameMode;
+  gameIndex: number;
+  userId: string;
+}): Promise<LeaderboardEntry | null> {
+  if (!supabase) return null;
+
+  const { data, error } = await supabase.rpc('get_game_leaderboard_placement', {
+    p_game_mode: input.gameMode,
+    p_game_index: input.gameIndex,
+    p_user_id: input.userId,
+  });
+
+  if (error) {
+    if (isTransientDatabaseError(error)) return null;
+    throw error;
+  }
+
+  const row = (data?.[0] ?? null) as
+    | {
+        rank: number;
+        user_id: string;
+        username: string | null;
+        guess_count: number;
+        finished_at: string;
+      }
+    | null;
+
+  if (!row) return null;
+
+  return {
+    rank: Number(row.rank ?? 0),
+    userId: row.user_id,
+    username: row.username ?? 'unknown',
+    guessCount: Number(row.guess_count ?? 0),
+    finishedAt: row.finished_at,
+  };
 }
 
 export async function loadUserProfile(userId: string) {

--- a/src/lib/gamePersistence.ts
+++ b/src/lib/gamePersistence.ts
@@ -405,15 +405,13 @@ export async function loadGameLeaderboardPlacement(input: {
     throw error;
   }
 
-  const row = (data?.[0] ?? null) as
-    | {
-        rank: number;
-        user_id: string;
-        username: string | null;
-        guess_count: number;
-        finished_at: string;
-      }
-    | null;
+  const row = (data?.[0] ?? null) as {
+    rank: number;
+    user_id: string;
+    username: string | null;
+    guess_count: number;
+    finished_at: string;
+  } | null;
 
   if (!row) return null;
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,8 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as TermsRouteImport } from './routes/terms'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as MoviesRouteImport } from './routes/movies'
 import { Route as DirectorsRouteImport } from './routes/directors'
 import { Route as AuthRouteImport } from './routes/auth'
@@ -16,6 +18,16 @@ import { Route as ArchiveRouteImport } from './routes/archive'
 import { Route as ActorsRouteImport } from './routes/actors'
 import { Route as IndexRouteImport } from './routes/index'
 
+const TermsRoute = TermsRouteImport.update({
+  id: '/terms',
+  path: '/terms',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MoviesRoute = MoviesRouteImport.update({
   id: '/movies',
   path: '/movies',
@@ -54,6 +66,8 @@ export interface FileRoutesByFullPath {
   '/auth': typeof AuthRoute
   '/directors': typeof DirectorsRoute
   '/movies': typeof MoviesRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -62,6 +76,8 @@ export interface FileRoutesByTo {
   '/auth': typeof AuthRoute
   '/directors': typeof DirectorsRoute
   '/movies': typeof MoviesRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -71,12 +87,30 @@ export interface FileRoutesById {
   '/auth': typeof AuthRoute
   '/directors': typeof DirectorsRoute
   '/movies': typeof MoviesRoute
+  '/privacy': typeof PrivacyRoute
+  '/terms': typeof TermsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/actors' | '/archive' | '/auth' | '/directors' | '/movies'
+  fullPaths:
+    | '/'
+    | '/actors'
+    | '/archive'
+    | '/auth'
+    | '/directors'
+    | '/movies'
+    | '/privacy'
+    | '/terms'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/actors' | '/archive' | '/auth' | '/directors' | '/movies'
+  to:
+    | '/'
+    | '/actors'
+    | '/archive'
+    | '/auth'
+    | '/directors'
+    | '/movies'
+    | '/privacy'
+    | '/terms'
   id:
     | '__root__'
     | '/'
@@ -85,6 +119,8 @@ export interface FileRouteTypes {
     | '/auth'
     | '/directors'
     | '/movies'
+    | '/privacy'
+    | '/terms'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -94,10 +130,26 @@ export interface RootRouteChildren {
   AuthRoute: typeof AuthRoute
   DirectorsRoute: typeof DirectorsRoute
   MoviesRoute: typeof MoviesRoute
+  PrivacyRoute: typeof PrivacyRoute
+  TermsRoute: typeof TermsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/terms': {
+      id: '/terms'
+      path: '/terms'
+      fullPath: '/terms'
+      preLoaderRoute: typeof TermsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/movies': {
       id: '/movies'
       path: '/movies'
@@ -150,6 +202,8 @@ const rootRouteChildren: RootRouteChildren = {
   AuthRoute: AuthRoute,
   DirectorsRoute: DirectorsRoute,
   MoviesRoute: MoviesRoute,
+  PrivacyRoute: PrivacyRoute,
+  TermsRoute: TermsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/actors.tsx
+++ b/src/routes/actors.tsx
@@ -78,10 +78,10 @@ function ActorsGame({ gameIndex }: { gameIndex: number }) {
       />
       {gameMode ? (
         <LeaderboardModal>
-             <h2 className="font-bold text-xl mb-4 text-primary">
-               <FaTrophy className="inline" />
-               &nbsp;Leaderboard
-             </h2>
+          <h2 className="font-bold text-xl mb-4 text-primary">
+            <FaTrophy className="inline" />
+            &nbsp;Leaderboard
+          </h2>
           <GameLeaderboard
             enabled={isConfigured}
             gameMode={gameMode}

--- a/src/routes/actors.tsx
+++ b/src/routes/actors.tsx
@@ -5,6 +5,11 @@ import GameHowToPlay from '../features/gameplay/components/GameHowToPlay';
 import useGame from '../features/gameplay/hooks/useGame';
 import useGameIndex from '../features/gameplay/hooks/useGameIndex';
 import { getRoute } from '../routes';
+import useModal from '../hooks/useModal';
+import useAuth from '../hooks/useAuth';
+import { toGameMode } from '../lib/gameMode';
+import GameLeaderboard from '../features/gameplay/components/GameLeaderboard';
+import { FaTrophy } from 'react-icons/fa';
 
 export const Route = createFileRoute('/actors')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -56,7 +61,10 @@ function Actors() {
 
 function ActorsGame({ gameIndex }: { gameIndex: number }) {
   const route = getRoute('actors');
-  const { gameBoard, stats } = useGame(route, actors, gameIndex);
+  const { user, isConfigured } = useAuth();
+  const gameMode = toGameMode(route.title);
+  const { Modal: LeaderboardModal, open: openLeaderboardModal } = useModal();
+  const { gameBoard, stats } = useGame(route, actors, gameIndex, openLeaderboardModal);
 
   return (
     <section id="actors" className="p-2">
@@ -65,7 +73,26 @@ function ActorsGame({ gameIndex }: { gameIndex: number }) {
         AboutContent={AboutContent}
         route={route}
         gameIndex={gameIndex}
+        onOpenLeaderboard={openLeaderboardModal}
+        showInlineLeaderboardModal={false}
       />
+      {gameMode ? (
+        <LeaderboardModal>
+             <h2 className="font-bold text-xl mb-4 text-primary">
+               <FaTrophy className="inline" />
+               &nbsp;Leaderboard
+             </h2>
+          <GameLeaderboard
+            enabled={isConfigured}
+            gameMode={gameMode}
+            gameIndex={gameIndex}
+            userId={user?.id ?? null}
+            pageSize={25}
+            showPagination
+            showTitle={false}
+          />
+        </LeaderboardModal>
+      ) : null}
       {gameBoard}
     </section>
   );

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -124,13 +124,7 @@ function OAuthButtons({
         )}{' '}
         Discord
       </button>
-      <button
-        className="btn"
-        type="button"
-        disabled={disabled || true}
-        title="Planned: enable in Supabase providers when ready"
-        onClick={() => onOAuth('google')}
-      >
+      <button className="btn" type="button" disabled={disabled} onClick={() => onOAuth('google')}>
         {activeProvider === 'google' ? (
           <span className="loading loading-spinner loading-sm" />
         ) : (
@@ -613,7 +607,9 @@ function AuthPage() {
               {isSendingReset ? 'Sending...' : 'Send Password Reset Email'}
             </button>
           ) : null}
-          <p className="text-xs text-base-content/60">Password reset works for email/password accounts.</p>
+          <p className="text-xs text-base-content/60">
+            Password reset works for email/password accounts.
+          </p>
         </TabForm>
 
         <TabForm

--- a/src/routes/auth.tsx
+++ b/src/routes/auth.tsx
@@ -171,6 +171,21 @@ function isValidUsername(input: string): boolean {
   return /^[a-z0-9_]{3,32}$/.test(input);
 }
 
+function hasEmailIdentity(user: NonNullable<ReturnType<typeof useAuth>['user']>): boolean {
+  const appMeta = (user.app_metadata ?? {}) as { provider?: string; providers?: string[] };
+  const providers = Array.isArray(appMeta.providers) ? appMeta.providers : [];
+
+  if (providers.includes('email') || appMeta.provider === 'email') {
+    return true;
+  }
+
+  const identities = Array.isArray(user.identities)
+    ? user.identities
+    : ((user as { identities?: Array<{ provider?: string }> }).identities ?? []);
+
+  return identities.some((identity) => identity?.provider === 'email');
+}
+
 function AuthPage() {
   const {
     isConfigured,
@@ -330,6 +345,8 @@ function AuthPage() {
   }
 
   if (user) {
+    const canManagePassword = hasEmailIdentity(user);
+
     const handlePasswordUpdate = async (event: React.FormEvent) => {
       event.preventDefault();
       resetState();
@@ -489,23 +506,31 @@ function AuthPage() {
           </div>
         </div>
 
-        <div className="card bg-base-200 border border-base-300">
-          <div className="card-body">
-            <h2 className="font-display text-lg mb-3">Change Password</h2>
-            <form onSubmit={handlePasswordUpdate} className="flex flex-col gap-4">
-              <PasswordInput
-                id="account-new-password"
-                label="New Password"
-                value={newPassword}
-                onChange={setNewPassword}
-              />
-              <button className="btn btn-primary" type="submit" disabled={isUpdatingPassword}>
-                {isUpdatingPassword && <span className="loading loading-spinner loading-sm" />}
-                {isUpdatingPassword ? 'Saving...' : 'Save New Password'}
-              </button>
-            </form>
+        {canManagePassword ? (
+          <div className="card bg-base-200 border border-base-300">
+            <div className="card-body">
+              <h2 className="font-display text-lg mb-3">Change Password</h2>
+              <form onSubmit={handlePasswordUpdate} className="flex flex-col gap-4">
+                <PasswordInput
+                  id="account-new-password"
+                  label="New Password"
+                  value={newPassword}
+                  onChange={setNewPassword}
+                />
+                <button className="btn btn-primary" type="submit" disabled={isUpdatingPassword}>
+                  {isUpdatingPassword && <span className="loading loading-spinner loading-sm" />}
+                  {isUpdatingPassword ? 'Saving...' : 'Save New Password'}
+                </button>
+              </form>
+            </div>
           </div>
-        </div>
+        ) : (
+          <div className="alert alert-info">
+            <span>
+              This account uses OAuth sign-in only. Password changes are managed by your provider.
+            </span>
+          </div>
+        )}
 
         <div className="card bg-base-200 border border-error/40">
           <div className="card-body">
@@ -577,15 +602,18 @@ function AuthPage() {
             {isSigningIn && <span className="loading loading-spinner loading-sm" />}
             {isSigningIn ? 'Signing in...' : 'Sign In'}
           </button>
-          <button
-            className="btn btn-ghost"
-            type="button"
-            onClick={onResetRequest}
-            disabled={isSigningIn || isSendingReset}
-          >
-            {isSendingReset && <span className="loading loading-spinner loading-sm" />}
-            {isSendingReset ? 'Sending...' : 'Send Password Reset Email'}
-          </button>
+          {email.trim() ? (
+            <button
+              className="btn btn-ghost"
+              type="button"
+              onClick={onResetRequest}
+              disabled={isSigningIn || isSendingReset}
+            >
+              {isSendingReset && <span className="loading loading-spinner loading-sm" />}
+              {isSendingReset ? 'Sending...' : 'Send Password Reset Email'}
+            </button>
+          ) : null}
+          <p className="text-xs text-base-content/60">Password reset works for email/password accounts.</p>
         </TabForm>
 
         <TabForm

--- a/src/routes/directors.tsx
+++ b/src/routes/directors.tsx
@@ -5,6 +5,11 @@ import GameHowToPlay from '../features/gameplay/components/GameHowToPlay';
 import useGame from '../features/gameplay/hooks/useGame';
 import useGameIndex from '../features/gameplay/hooks/useGameIndex';
 import { getRoute } from '../routes';
+import useModal from '../hooks/useModal';
+import useAuth from '../hooks/useAuth';
+import { toGameMode } from '../lib/gameMode';
+import GameLeaderboard from '../features/gameplay/components/GameLeaderboard';
+import { FaTrophy } from 'react-icons/fa';
 
 export const Route = createFileRoute('/directors')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -56,7 +61,10 @@ function Directors() {
 
 function DirectorsGame({ gameIndex }: { gameIndex: number }) {
   const route = getRoute('directors');
-  const { gameBoard, stats } = useGame(route, directors, gameIndex);
+  const { user, isConfigured } = useAuth();
+  const gameMode = toGameMode(route.title);
+  const { Modal: LeaderboardModal, open: openLeaderboardModal } = useModal();
+  const { gameBoard, stats } = useGame(route, directors, gameIndex, openLeaderboardModal);
 
   return (
     <section id="directors" className="p-2">
@@ -65,7 +73,26 @@ function DirectorsGame({ gameIndex }: { gameIndex: number }) {
         AboutContent={AboutContent}
         route={route}
         gameIndex={gameIndex}
+        onOpenLeaderboard={openLeaderboardModal}
+        showInlineLeaderboardModal={false}
       />
+      {gameMode ? (
+        <LeaderboardModal>
+          <h2 className="font-bold text-xl mb-4 text-primary">
+            <FaTrophy className="inline" />
+            &nbsp;Leaderboard
+          </h2>
+          <GameLeaderboard
+            enabled={isConfigured}
+            gameMode={gameMode}
+            gameIndex={gameIndex}
+            userId={user?.id ?? null}
+            pageSize={25}
+            showPagination
+            showTitle={false}
+          />
+        </LeaderboardModal>
+      ) : null}
       {gameBoard}
     </section>
   );

--- a/src/routes/movies.tsx
+++ b/src/routes/movies.tsx
@@ -5,6 +5,11 @@ import GameHowToPlay from '../features/gameplay/components/GameHowToPlay';
 import useGame from '../features/gameplay/hooks/useGame';
 import useGameIndex from '../features/gameplay/hooks/useGameIndex';
 import { getRoute } from '../routes';
+import useModal from '../hooks/useModal';
+import useAuth from '../hooks/useAuth';
+import { toGameMode } from '../lib/gameMode';
+import GameLeaderboard from '../features/gameplay/components/GameLeaderboard';
+import { FaTrophy } from 'react-icons/fa';
 
 export const Route = createFileRoute('/movies')({
   validateSearch: (search: Record<string, unknown>) => ({
@@ -56,7 +61,10 @@ function Movies() {
 
 function MoviesGame({ gameIndex }: { gameIndex: number }) {
   const route = getRoute('movies');
-  const { gameBoard, stats } = useGame(route, movies, gameIndex);
+  const { user, isConfigured } = useAuth();
+  const gameMode = toGameMode(route.title);
+  const { Modal: LeaderboardModal, open: openLeaderboardModal } = useModal();
+  const { gameBoard, stats } = useGame(route, movies, gameIndex, openLeaderboardModal);
 
   return (
     <section id="movies" className="p-2">
@@ -65,7 +73,26 @@ function MoviesGame({ gameIndex }: { gameIndex: number }) {
         AboutContent={AboutContent}
         route={route}
         gameIndex={gameIndex}
+        onOpenLeaderboard={openLeaderboardModal}
+        showInlineLeaderboardModal={false}
       />
+      {gameMode ? (
+        <LeaderboardModal>
+          <h2 className="font-bold text-xl mb-4 text-primary">
+            <FaTrophy className="inline" />
+            &nbsp;Leaderboard
+          </h2>
+          <GameLeaderboard
+            enabled={isConfigured}
+            gameMode={gameMode}
+            gameIndex={gameIndex}
+            userId={user?.id ?? null}
+            pageSize={25}
+            showPagination
+            showTitle={false}
+          />
+        </LeaderboardModal>
+      ) : null}
       {gameBoard}
     </section>
   );

--- a/src/routes/privacy.tsx
+++ b/src/routes/privacy.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/privacy')({
+  component: PrivacyPolicyPage,
+});
+
+function PrivacyPolicyPage() {
+  return (
+    <section className="p-3 flex flex-col gap-4 max-w-3xl">
+      <h1 className="text-2xl font-display">Privacy Policy</h1>
+      <p className="text-sm text-base-content/70">Last updated: March 21, 2026</p>
+
+      <p>
+        kino.wtf respects your privacy. This page explains what data is collected, how it is used,
+        and what choices you have.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">What we collect</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>Gameplay data such as guesses, results, and game progress.</li>
+          <li>Account information when you sign in (such as email and provider identity).</li>
+          <li>Profile preferences such as username and theme settings.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">How we use data</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>To run the game and save your progress.</li>
+          <li>To sync your game history and stats when you are signed in.</li>
+          <li>To improve reliability, security, and product quality.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Storage and providers</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>Local game progress can be stored in your browser local storage.</li>
+          <li>Account-backed authentication and persistence are handled through Supabase.</li>
+          <li>OAuth sign-in uses third-party providers such as Discord or Google.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Your choices</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>You can play without creating an account.</li>
+          <li>You can sign out at any time.</li>
+          <li>You can request account deletion from the auth page when signed in.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Contact</h2>
+        <p>
+          For privacy questions, contact{' '}
+          <a className="link link-primary" href="mailto:info@kino.wtf">
+            info@kino.wtf
+          </a>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/routes/terms.tsx
+++ b/src/routes/terms.tsx
@@ -1,0 +1,66 @@
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/terms')({
+  component: TermsOfServicePage,
+});
+
+function TermsOfServicePage() {
+  return (
+    <section className="p-3 flex flex-col gap-4 max-w-3xl">
+      <h1 className="text-2xl font-display">Terms of Service</h1>
+      <p className="text-sm text-base-content/70">Last updated: March 21, 2026</p>
+
+      <p>
+        By accessing or using kino.wtf, you agree to these terms. If you do not agree, do not use
+        the service.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Use of the service</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>You may use kino.wtf for personal, non-commercial entertainment.</li>
+          <li>You agree not to abuse, disrupt, or attempt to compromise the service.</li>
+          <li>You are responsible for activity performed through your account.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Accounts and authentication</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>You may play without an account, or sign in for synced progress and stats.</li>
+          <li>OAuth and authentication are provided through third-party services.</li>
+          <li>We may suspend access for misuse, fraud, or abuse.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Content and availability</h2>
+        <ul className="list-disc pl-6 flex flex-col gap-1">
+          <li>Game content and features may change at any time without notice.</li>
+          <li>The service is provided on an "as is" and "as available" basis.</li>
+          <li>We do not guarantee uninterrupted availability or error-free operation.</li>
+        </ul>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Limitation of liability</h2>
+        <p>
+          To the fullest extent permitted by law, kino.wtf and its operators are not liable for
+          indirect, incidental, special, consequential, or punitive damages arising from your use of
+          the service.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <h2 className="text-lg font-semibold">Contact</h2>
+        <p>
+          For terms questions, contact{' '}
+          <a className="link link-primary" href="mailto:info@kino.wtf">
+            info@kino.wtf
+          </a>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/supabase/migrations/202603210130_add_game_leaderboard_rpc.sql
+++ b/supabase/migrations/202603210130_add_game_leaderboard_rpc.sql
@@ -1,0 +1,117 @@
+-- Winners-only leaderboard RPCs for game end screens and full leaderboard modal.
+
+create index if not exists idx_played_games_leaderboard_winners
+  on public.played_games (
+    game_mode,
+    game_index,
+    did_win,
+    (coalesce(array_length(guesses, 1), 0)),
+    finished_at,
+    user_id
+  )
+  where did_win = true;
+
+create or replace function public.get_game_leaderboard_page(
+  p_game_mode text,
+  p_game_index integer,
+  p_page integer default 1,
+  p_page_size integer default 25
+)
+returns table (
+  rank bigint,
+  user_id uuid,
+  username text,
+  guess_count integer,
+  finished_at timestamptz,
+  total_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with winners as (
+    select
+      pg.user_id,
+      coalesce(up.username, 'user_' || substring(replace(pg.user_id::text, '-', ''), 1, 8)) as username,
+      coalesce(array_length(pg.guesses, 1), 0) as guess_count,
+      pg.finished_at,
+      row_number() over (
+        order by
+          coalesce(array_length(pg.guesses, 1), 0) asc,
+          pg.finished_at asc,
+          pg.user_id asc
+      ) as rank,
+      count(*) over () as total_count
+    from public.played_games pg
+    left join public.user_profiles up on up.id = pg.user_id
+    where pg.game_mode = p_game_mode
+      and pg.game_index = p_game_index
+      and pg.did_win = true
+  )
+  select
+    w.rank,
+    w.user_id,
+    w.username,
+    w.guess_count,
+    w.finished_at,
+    w.total_count
+  from winners w
+  where w.rank > ((greatest(p_page, 1) - 1) * greatest(p_page_size, 1))
+    and w.rank <= (greatest(p_page, 1) * greatest(p_page_size, 1))
+  order by w.rank asc;
+$$;
+
+create or replace function public.get_game_leaderboard_placement(
+  p_game_mode text,
+  p_game_index integer,
+  p_user_id uuid
+)
+returns table (
+  rank bigint,
+  user_id uuid,
+  username text,
+  guess_count integer,
+  finished_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with winners as (
+    select
+      pg.user_id,
+      coalesce(up.username, 'user_' || substring(replace(pg.user_id::text, '-', ''), 1, 8)) as username,
+      coalesce(array_length(pg.guesses, 1), 0) as guess_count,
+      pg.finished_at,
+      row_number() over (
+        order by
+          coalesce(array_length(pg.guesses, 1), 0) asc,
+          pg.finished_at asc,
+          pg.user_id asc
+      ) as rank
+    from public.played_games pg
+    left join public.user_profiles up on up.id = pg.user_id
+    where pg.game_mode = p_game_mode
+      and pg.game_index = p_game_index
+      and pg.did_win = true
+  )
+  select
+    w.rank,
+    w.user_id,
+    w.username,
+    w.guess_count,
+    w.finished_at
+  from winners w
+  where w.user_id = p_user_id
+  limit 1;
+$$;
+
+revoke all on function public.get_game_leaderboard_page(text, integer, integer, integer) from public;
+grant execute on function public.get_game_leaderboard_page(text, integer, integer, integer) to anon;
+grant execute on function public.get_game_leaderboard_page(text, integer, integer, integer) to authenticated;
+
+revoke all on function public.get_game_leaderboard_placement(text, integer, uuid) from public;
+grant execute on function public.get_game_leaderboard_placement(text, integer, uuid) to anon;
+grant execute on function public.get_game_leaderboard_placement(text, integer, uuid) to authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -224,3 +224,119 @@ create policy "Users can update own played games"
   for update
   using (auth.uid() = user_id)
   with check (auth.uid() = user_id);
+
+create index if not exists idx_played_games_leaderboard_winners
+  on public.played_games (
+    game_mode,
+    game_index,
+    did_win,
+    (coalesce(array_length(guesses, 1), 0)),
+    finished_at,
+    user_id
+  )
+  where did_win = true;
+
+create or replace function public.get_game_leaderboard_page(
+  p_game_mode text,
+  p_game_index integer,
+  p_page integer default 1,
+  p_page_size integer default 25
+)
+returns table (
+  rank bigint,
+  user_id uuid,
+  username text,
+  guess_count integer,
+  finished_at timestamptz,
+  total_count bigint
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with winners as (
+    select
+      pg.user_id,
+      coalesce(up.username, 'user_' || substring(replace(pg.user_id::text, '-', ''), 1, 8)) as username,
+      coalesce(array_length(pg.guesses, 1), 0) as guess_count,
+      pg.finished_at,
+      row_number() over (
+        order by
+          coalesce(array_length(pg.guesses, 1), 0) asc,
+          pg.finished_at asc,
+          pg.user_id asc
+      ) as rank,
+      count(*) over () as total_count
+    from public.played_games pg
+    left join public.user_profiles up on up.id = pg.user_id
+    where pg.game_mode = p_game_mode
+      and pg.game_index = p_game_index
+      and pg.did_win = true
+  )
+  select
+    w.rank,
+    w.user_id,
+    w.username,
+    w.guess_count,
+    w.finished_at,
+    w.total_count
+  from winners w
+  where w.rank > ((greatest(p_page, 1) - 1) * greatest(p_page_size, 1))
+    and w.rank <= (greatest(p_page, 1) * greatest(p_page_size, 1))
+  order by w.rank asc;
+$$;
+
+create or replace function public.get_game_leaderboard_placement(
+  p_game_mode text,
+  p_game_index integer,
+  p_user_id uuid
+)
+returns table (
+  rank bigint,
+  user_id uuid,
+  username text,
+  guess_count integer,
+  finished_at timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  with winners as (
+    select
+      pg.user_id,
+      coalesce(up.username, 'user_' || substring(replace(pg.user_id::text, '-', ''), 1, 8)) as username,
+      coalesce(array_length(pg.guesses, 1), 0) as guess_count,
+      pg.finished_at,
+      row_number() over (
+        order by
+          coalesce(array_length(pg.guesses, 1), 0) asc,
+          pg.finished_at asc,
+          pg.user_id asc
+      ) as rank
+    from public.played_games pg
+    left join public.user_profiles up on up.id = pg.user_id
+    where pg.game_mode = p_game_mode
+      and pg.game_index = p_game_index
+      and pg.did_win = true
+  )
+  select
+    w.rank,
+    w.user_id,
+    w.username,
+    w.guess_count,
+    w.finished_at
+  from winners w
+  where w.user_id = p_user_id
+  limit 1;
+$$;
+
+revoke all on function public.get_game_leaderboard_page(text, integer, integer, integer) from public;
+grant execute on function public.get_game_leaderboard_page(text, integer, integer, integer) to anon;
+grant execute on function public.get_game_leaderboard_page(text, integer, integer, integer) to authenticated;
+
+revoke all on function public.get_game_leaderboard_placement(text, integer, uuid) from public;
+grant execute on function public.get_game_leaderboard_placement(text, integer, uuid) to anon;
+grant execute on function public.get_game_leaderboard_placement(text, integer, uuid) to authenticated;

--- a/supabase/seed/README.md
+++ b/supabase/seed/README.md
@@ -1,0 +1,88 @@
+# Supabase Seed Scripts
+
+This folder contains SQL scripts used for leaderboard development and visual testing.
+
+## Files
+
+- `leaderboard_auth_users_seed.sql`
+Creates synthetic email users in `auth.users` (pattern: `leaderboard_seed_###@kino.wtf`).
+
+- `leaderboard_dev_seed.sql`
+Creates mixed outcomes in `public.played_games` across a rolling window of game indexes using existing auth users:
+- daily modes (`actors`, `movies`): current + previous 13 indexes
+- weekly mode (`directors`): current + previous 5 indexes
+This also avoids local timezone/DST off-by-one gaps during frontend testing.
+It now seeds additional edge cases, including:
+- wins with variable guess counts (1..6)
+- losses with all skipped guesses ("give up" style)
+- losses with mixed wrong guesses and skips
+
+- `leaderboard_seed_cleanup.sql`
+Removes seeded leaderboard rows and seeded synthetic users.
+
+- `game_stats_backfill_from_archive.sql`
+Recomputes `public.game_stats` from `public.played_games` for all users and modes.
+Use this if stats/history ever drift (for example after manual SQL or older seed runs).
+
+## When to use
+
+Use these scripts when testing:
+
+- endscreen top 5 leaderboard
+- endscreen personal placement row after divider (`...`)
+- full leaderboard modal pagination
+- stats and history consistency for mixed win/loss archives
+- loss rendering states in guess history
+
+## Prerequisites
+
+- Supabase project is linked in this repo.
+- Leaderboard migration is applied.
+
+```sh
+npx supabase db push --yes
+```
+
+## Seed (Linked Project)
+
+```sh
+npx supabase db query --linked -f supabase/seed/leaderboard_auth_users_seed.sql
+npx supabase db query --linked -f supabase/seed/leaderboard_dev_seed.sql
+npx supabase db query --linked -f supabase/seed/game_stats_backfill_from_archive.sql
+```
+
+## Verify
+
+```sh
+npx supabase db query --linked "select count(*) as total_auth_users from auth.users;"
+
+npx supabase db query --linked "
+with idx as (
+  select
+    greatest((current_date - date '2025-12-31')::int, 0) as daily_index,
+    greatest((((current_date - ((extract(dow from current_date)::int + 6) % 7)) - (date '2025-12-31' - ((extract(dow from date '2025-12-31')::int + 6) % 7))) / 7), 0)::int as weekly_index
+)
+select pg.game_mode, count(*) as winner_count
+from public.played_games pg
+cross join idx
+where pg.did_win = true
+  and (
+    (pg.game_mode in ('actors','movies') and pg.game_index = idx.daily_index)
+    or
+    (pg.game_mode = 'directors' and pg.game_index = idx.weekly_index)
+  )
+group by pg.game_mode
+order by pg.game_mode;
+"
+```
+
+## Cleanup
+
+```sh
+npx supabase db query --linked -f supabase/seed/leaderboard_seed_cleanup.sql
+```
+
+## Notes
+
+- Seed scripts are idempotent-safe for normal dev reuse.
+- Seeded rows do not expire automatically; cleanup is manual.

--- a/supabase/seed/README.md
+++ b/supabase/seed/README.md
@@ -5,24 +5,24 @@ This folder contains SQL scripts used for leaderboard development and visual tes
 ## Files
 
 - `leaderboard_auth_users_seed.sql`
-Creates synthetic email users in `auth.users` (pattern: `leaderboard_seed_###@kino.wtf`).
+  Creates synthetic email users in `auth.users` (pattern: `leaderboard_seed_###@kino.wtf`).
 
 - `leaderboard_dev_seed.sql`
-Creates mixed outcomes in `public.played_games` across a rolling window of game indexes using existing auth users:
+  Creates mixed outcomes in `public.played_games` across a rolling window of game indexes using existing auth users:
 - daily modes (`actors`, `movies`): current + previous 13 indexes
 - weekly mode (`directors`): current + previous 5 indexes
-This also avoids local timezone/DST off-by-one gaps during frontend testing.
-It now seeds additional edge cases, including:
+  This also avoids local timezone/DST off-by-one gaps during frontend testing.
+  It now seeds additional edge cases, including:
 - wins with variable guess counts (1..6)
 - losses with all skipped guesses ("give up" style)
 - losses with mixed wrong guesses and skips
 
 - `leaderboard_seed_cleanup.sql`
-Removes seeded leaderboard rows and seeded synthetic users.
+  Removes seeded leaderboard rows and seeded synthetic users.
 
 - `game_stats_backfill_from_archive.sql`
-Recomputes `public.game_stats` from `public.played_games` for all users and modes.
-Use this if stats/history ever drift (for example after manual SQL or older seed runs).
+  Recomputes `public.game_stats` from `public.played_games` for all users and modes.
+  Use this if stats/history ever drift (for example after manual SQL or older seed runs).
 
 ## When to use
 

--- a/supabase/seed/game_stats_backfill_from_archive.sql
+++ b/supabase/seed/game_stats_backfill_from_archive.sql
@@ -1,0 +1,86 @@
+-- Backfill game_stats from played_games archive for all users/modes.
+-- Useful after synthetic seed operations or integrity drift.
+
+with ordered as (
+  select
+    pg.user_id,
+    pg.game_mode,
+    pg.did_win,
+    row_number() over (
+      partition by pg.user_id, pg.game_mode
+      order by pg.game_index asc, pg.finished_at asc
+    ) as pos,
+    count(*) over (partition by pg.user_id, pg.game_mode) as total_games
+  from public.played_games pg
+),
+summary as (
+  select
+    o.user_id,
+    o.game_mode,
+    max(o.total_games)::int as games_played,
+    count(*) filter (where o.did_win)::int as games_won,
+    max(o.pos) filter (where o.did_win = false) as latest_loss_pos
+  from ordered o
+  group by o.user_id, o.game_mode
+),
+wins_only as (
+  select
+    o.user_id,
+    o.game_mode,
+    o.pos,
+    o.pos
+      - row_number() over (
+          partition by o.user_id, o.game_mode
+          order by o.pos
+        ) as run_group
+  from ordered o
+  where o.did_win = true
+),
+run_lengths as (
+  select
+    w.user_id,
+    w.game_mode,
+    count(*)::int as run_length
+  from wins_only w
+  group by w.user_id, w.game_mode, w.run_group
+),
+agg as (
+  select
+    s.user_id,
+    s.game_mode,
+    s.games_played,
+    s.games_won,
+    case
+      when s.games_played = 0 then 0
+      when s.latest_loss_pos is null then s.games_played
+      else s.games_played - s.latest_loss_pos
+    end::int as streak,
+    coalesce(max(rl.run_length), 0)::int as max_streak
+  from summary s
+  left join run_lengths rl
+    on rl.user_id = s.user_id
+   and rl.game_mode = s.game_mode
+  group by s.user_id, s.game_mode, s.games_played, s.games_won, s.latest_loss_pos
+)
+insert into public.game_stats (
+  user_id,
+  game_mode,
+  games_played,
+  games_won,
+  streak,
+  max_streak
+)
+select
+  a.user_id,
+  a.game_mode,
+  a.games_played,
+  a.games_won,
+  a.streak,
+  a.max_streak
+from agg a
+on conflict (user_id, game_mode)
+do update set
+  games_played = excluded.games_played,
+  games_won = excluded.games_won,
+  streak = excluded.streak,
+  max_streak = excluded.max_streak;

--- a/supabase/seed/leaderboard_auth_users_seed.sql
+++ b/supabase/seed/leaderboard_auth_users_seed.sql
@@ -1,0 +1,43 @@
+-- Dev seed to create real auth users for leaderboard testing.
+-- Safe to re-run: inserts only users that do not already exist by email.
+
+with seed_users as (
+  select
+    gs as seq,
+    format('leaderboard_seed_%s@kino.wtf', lpad(gs::text, 3, '0')) as email,
+    format('seed_user_%s', lpad(gs::text, 3, '0')) as username
+  from generate_series(1, 30) as gs
+)
+insert into auth.users (
+  id,
+  aud,
+  role,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  raw_app_meta_data,
+  raw_user_meta_data,
+  created_at,
+  updated_at,
+  is_sso_user,
+  is_anonymous
+)
+select
+  gen_random_uuid(),
+  'authenticated',
+  'authenticated',
+  su.email,
+  crypt(gen_random_uuid()::text, gen_salt('bf')),
+  now(),
+  '{"provider":"email","providers":["email"]}'::jsonb,
+  jsonb_build_object('username', su.username),
+  now() - make_interval(mins => (120 + su.seq)::int),
+  now(),
+  false,
+  false
+from seed_users su
+where not exists (
+  select 1
+  from auth.users au
+  where au.email = su.email
+);

--- a/supabase/seed/leaderboard_dev_seed.sql
+++ b/supabase/seed/leaderboard_dev_seed.sql
@@ -1,0 +1,243 @@
+-- Dev seed for leaderboard testing.
+-- Inserts mixed outcomes (wins + losses) for each existing auth user per game mode
+-- across a rolling window:
+-- - Daily modes (actors/movies): current index and previous 13 indexes (14 total)
+-- - Weekly mode (directors): current index and previous 5 indexes (6 total)
+
+with seed_users as (
+  select
+    id,
+    row_number() over (order by created_at asc, id asc) as user_rank
+  from auth.users
+  order by created_at asc, id asc
+  limit 50
+),
+indexes as (
+  select
+    greatest((current_date - date '2025-12-31')::int, 0) as daily_index,
+    greatest(
+      (
+        (
+          current_date - ((extract(dow from current_date)::int + 6) % 7)
+        ) - (
+          date '2025-12-31' - ((extract(dow from date '2025-12-31')::int + 6) % 7)
+        )
+      ) / 7,
+      0
+    )::int as weekly_index
+),
+target_indexes as (
+  select
+    greatest(idx.daily_index + offs.offset_days, 0) as daily_index
+  from indexes idx
+  cross join generate_series(-13, 0) as offs(offset_days)
+),
+weekly_target_indexes as (
+  select
+    greatest(idx.weekly_index + offs.offset_weeks, 0) as weekly_index
+  from indexes idx
+  cross join generate_series(-5, 0) as offs(offset_weeks)
+),
+seed_rows as (
+  select
+    su.id as user_id,
+    valueset.game_mode,
+    idxsel.game_index,
+    concat('Seeded ', valueset.mode_label, ' Answer #', su.user_rank) as answer_title,
+    outcome.did_win,
+    case
+      when outcome.did_win then
+        array(
+          select case
+            when gs = outcome.win_guess_count then
+              concat('Seeded ', valueset.mode_label, ' Answer #', su.user_rank)
+            else 'Skipped'
+          end
+          from generate_series(1, outcome.win_guess_count) as gs
+        )::text[]
+      when outcome.loss_pattern = 0 then
+        -- Give-up style loss: all skips.
+        array_fill(''::text, array[6])
+      when outcome.loss_pattern = 1 then
+        -- Near-miss style: five wrong guesses, then final skip.
+        array(
+          select case
+            when gs = 6 then ''
+            else concat('Seeded ', valueset.mode_label, ' Wrong #', (((mix.mix_seed + gs) % 200) + 1))
+          end
+          from generate_series(1, 6) as gs
+        )::text[]
+      else
+        -- Mixed loss: alternating wrong guesses and skips.
+        array(
+          select case
+            when gs % 2 = 0 then ''
+            else concat('Seeded ', valueset.mode_label, ' Wrong #', (((mix.mix_seed + gs) % 200) + 1))
+          end
+          from generate_series(1, 6) as gs
+        )::text[]
+    end as guesses,
+    now()
+      - make_interval(
+          mins => (((mix.mix_seed % 180) + (su.user_rank * 2) + valueset.finish_offset_minutes)::int)
+        ) as finished_at
+  from seed_users su
+  cross join (
+    values
+      ('actors'::text, 'Actor'::text, 0::int, 18::int),
+      ('movies'::text, 'Movie'::text, 2::int, 11::int),
+      ('directors'::text, 'Director'::text, 4::int, 24::int)
+  ) as valueset(game_mode, mode_label, guess_seed, finish_offset_minutes)
+  cross join lateral (
+    select d.daily_index as game_index
+    from target_indexes d
+    where valueset.game_mode in ('actors', 'movies')
+    union all
+    select w.weekly_index as game_index
+    from weekly_target_indexes w
+    where valueset.game_mode = 'directors'
+  ) idxsel
+  cross join lateral (
+    select
+      (
+        (
+          (
+            'x' || substr(
+              md5(
+                concat(
+                  valueset.game_mode,
+                  ':',
+                  idxsel.game_index,
+                  ':',
+                  su.id::text
+                )
+              ),
+              1,
+              8
+            )
+          )::bit(32)::int
+        ) & 2147483647
+      ) as mix_seed
+  ) mix
+  cross join lateral (
+    select
+      (((mix.mix_seed + su.user_rank + idxsel.game_index + valueset.guess_seed) % 10) < 7) as did_win,
+      (((mix.mix_seed + valueset.guess_seed) % 6) + 1) as win_guess_count,
+      ((mix.mix_seed + su.user_rank + idxsel.game_index) % 4) as loss_pattern
+  ) outcome
+)
+insert into public.played_games (
+  user_id,
+  game_mode,
+  game_index,
+  answer_title,
+  did_win,
+  guesses,
+  finished_at
+)
+select
+  sr.user_id,
+  sr.game_mode,
+  sr.game_index,
+  sr.answer_title,
+  sr.did_win,
+  sr.guesses,
+  sr.finished_at
+from seed_rows sr
+on conflict (user_id, game_mode, game_index)
+do update set
+  answer_title = excluded.answer_title,
+  did_win = excluded.did_win,
+  guesses = excluded.guesses,
+  finished_at = excluded.finished_at;
+
+-- Recompute mode-scoped game_stats for seeded users from their archive rows.
+with seeded_users as (
+  select id
+  from auth.users
+  where email like 'leaderboard_seed_%@kino.wtf'
+),
+ordered as (
+  select
+    pg.user_id,
+    pg.game_mode,
+    pg.did_win,
+    row_number() over (
+      partition by pg.user_id, pg.game_mode
+      order by pg.game_index asc, pg.finished_at asc
+    ) as pos,
+    count(*) over (partition by pg.user_id, pg.game_mode) as total_games
+  from public.played_games pg
+  inner join seeded_users su on su.id = pg.user_id
+),
+summary as (
+  select
+    o.user_id,
+    o.game_mode,
+    max(o.total_games)::int as games_played,
+    count(*) filter (where o.did_win)::int as games_won,
+    max(o.pos) filter (where o.did_win = false) as latest_loss_pos
+  from ordered o
+  group by o.user_id, o.game_mode
+),
+wins_only as (
+  select
+    o.user_id,
+    o.game_mode,
+    o.pos,
+    o.pos
+      - row_number() over (
+          partition by o.user_id, o.game_mode
+          order by o.pos
+        ) as run_group
+  from ordered o
+  where o.did_win = true
+),
+run_lengths as (
+  select
+    w.user_id,
+    w.game_mode,
+    count(*)::int as run_length
+  from wins_only w
+  group by w.user_id, w.game_mode, w.run_group
+),
+agg as (
+  select
+    s.user_id,
+    s.game_mode,
+    s.games_played,
+    s.games_won,
+    case
+      when s.games_played = 0 then 0
+      when s.latest_loss_pos is null then s.games_played
+      else s.games_played - s.latest_loss_pos
+    end::int as streak,
+    coalesce(max(rl.run_length), 0)::int as max_streak
+  from summary s
+  left join run_lengths rl
+    on rl.user_id = s.user_id
+   and rl.game_mode = s.game_mode
+  group by s.user_id, s.game_mode, s.games_played, s.games_won, s.latest_loss_pos
+)
+insert into public.game_stats (
+  user_id,
+  game_mode,
+  games_played,
+  games_won,
+  streak,
+  max_streak
+)
+select
+  a.user_id,
+  a.game_mode,
+  a.games_played,
+  a.games_won,
+  a.streak,
+  a.max_streak
+from agg a
+on conflict (user_id, game_mode)
+do update set
+  games_played = excluded.games_played,
+  games_won = excluded.games_won,
+  streak = excluded.streak,
+  max_streak = excluded.max_streak;

--- a/supabase/seed/leaderboard_seed_cleanup.sql
+++ b/supabase/seed/leaderboard_seed_cleanup.sql
@@ -1,0 +1,13 @@
+-- Cleanup for leaderboard development seeds.
+-- Removes synthetic auth users and any related seeded rows.
+-- Safe to re-run.
+
+-- Remove any seeded winner rows that use the explicit seeded title prefix.
+delete from public.played_games
+where answer_title like 'Seeded % Winner #%'
+	or answer_title like 'Seeded % Answer #%';
+
+-- Remove synthetic auth users created by leaderboard_auth_users_seed.sql.
+-- Cascades to related public.user_profiles / game_stats / game_states / played_games rows.
+delete from auth.users
+where email like 'leaderboard_seed_%@kino.wtf';


### PR DESCRIPTION
Summary
- Adds winners-only leaderboard support with top 5 on endscreen and full paginated modal access.
- Hardens gameplay persistence and hydration to prevent stale overwrites and completion/state race issues.
- Improves auth account UX for OAuth-only users around password/reset controls.
- Adds robust Supabase seed, cleanup, and stats backfill scripts for local/dev QA.
- Documents indexing and stats canonical-source rules in project spec.

What changed
- Leaderboard UI/component and route wiring:
  - GameLeaderboard.tsx
  - GameNavigation.tsx
  - actors.tsx
  - movies.tsx
  - directors.tsx
- Gameplay persistence/stats hardening:
  - useGame.tsx
  - gamePersistence.ts
- Auth UX adjustments:
  - auth.tsx
- Database objects and migration:
  - 202603210130_add_game_leaderboard_rpc.sql
  - schema.sql
- Seed tooling and docs:
  - leaderboard_auth_users_seed.sql
  - leaderboard_dev_seed.sql
  - leaderboard_seed_cleanup.sql
  - game_stats_backfill_from_archive.sql
  - README.md
  - README.md
- Spec update:
  - PROJECT_SPEC.md

Notes for reviewers
- Leaderboard ranking is deterministic and tie-broken by guess count, then finish time, then user id.
- Stats recompute/backfill now uses game chronology (game_index first), avoiding streak undercount from timestamp ordering.
- Stats and played history are treated as archive-canonical for played/won integrity.
- Seed data has been cleaned from linked DB prior to PR.